### PR TITLE
Fix skill-tree in deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ rust:
   - stable
 
 before_script:
-  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.3" mdbook)
-  - (test -x $HOME/.cargo/bin/skill-tree || cargo install --vers "^1.3.1" skill-tree)
-  - cargo install-update -a
+  - cargo install --version "^0.3" mdbook
+  - cargo install --version "^1.3.1" skill-tree
 
 script:
   - mdbook build && mdbook test


### PR DESCRIPTION
Right now in CI we use `cargo-update` to update binaries, but this updates them to semver incompatible versions. So in CI we update `skill-tree` to `2.0` even though it's not compatible with our current setup, which breaks the skill-tree in the deployed website. Also `cargo install` now properly handles updates, so we shouldn't need to use `cargo-update` anymore.